### PR TITLE
Add unique target group name for bastion host elb

### DIFF
--- a/.dazn-manifest.yml
+++ b/.dazn-manifest.yml
@@ -1,0 +1,5 @@
+dazn-manifest: 0.0.2
+info:
+  name: terraform-aws-ssh-bastion-service
+  description: stateless containerised sshd bastion service on AWS with IAM based authentication
+  owner: CE

--- a/CHANGELOG/2020-04-16-PLAT-3903_rds_proxy_accessible_through_bastions.yml
+++ b/CHANGELOG/2020-04-16-PLAT-3903_rds_proxy_accessible_through_bastions.yml
@@ -1,0 +1,4 @@
+- type: changed
+  m: Add unique target group name for bastion host elb
+  jira: PLAT-3903
+  owner: simonkey007

--- a/load_balancer.tf
+++ b/load_balancer.tf
@@ -67,7 +67,7 @@ resource "aws_lb_target_group" "bastion-service" {
 #######################################################	
 resource "aws_lb_target_group" "bastion-host" {
   count    = local.hostport_whitelisted ? 1 : 0
-  name     = "bastion-host"
+  name     = md5(format("${var.bastion_host_name}-%s", var.vpc))
   protocol = "TCP"
   port     = 2222
   vpc_id   = var.vpc


### PR DESCRIPTION
We use this module for rds proxy and we have 2 rds proxy instances (dev/stage) per each region on DAZN-DEV account. We have to use a unique names for LB target groups for this specific scenario.