### PR TITLE
Delete network interface on instance termination

### DIFF
--- a/CHANGELOG/2020-06-12-master.yml
+++ b/CHANGELOG/2020-06-12-master.yml
@@ -1,0 +1,3 @@
+- type: changed
+  m: Delete network interface on instance termination
+  owner: mwieczorek

--- a/main.tf
+++ b/main.tf
@@ -45,6 +45,7 @@ resource "aws_launch_template" "bastion-service-host" {
 
   network_interfaces {
     associate_public_ip_address = var.public_ip
+    delete_on_termination       = var.delete_network_interface_on_termination
     security_groups = concat(
       [aws_security_group.bastion_service.id],
       var.security_groups_additional

--- a/variables.tf
+++ b/variables.tf
@@ -206,3 +206,8 @@ variable "on_demand_base_capacity" {
   default     = 0
   description = "allows a base level of on demand when using spot"
 }
+
+variable "delete_network_interface_on_termination" {
+  description = "if network interface created for bastion host should be deleted when instance in terminated. Setting propagated to aws_launch_template.network_interfaces.delete_on_termination"
+  default = true
+}


### PR DESCRIPTION
to fix the 'leaking' network interfaces